### PR TITLE
Removed query string from nodeActive comparison

### DIFF
--- a/services/NaveeService.php
+++ b/services/NaveeService.php
@@ -147,7 +147,7 @@ class NaveeService extends BaseApplicationComponent {
   private function nodeActive(Navee_NodeModel $node)
   {
     $data       = false;
-    $currentUri = ltrim(craft()->request->getRequestUri(), '/');
+    $currentUri = ltrim(craft()->request->getPath(), '/');
     $link       = ltrim($node->link, '/');
 
     if (($link == $currentUri) && !$node->passive)


### PR DESCRIPTION
I noticed a small issue where including any query string on a URL prevents the active class from being applied to that node. I switched from `craft()->request->getRequestUri()` to `craft()->request->getPath()` so the query string wouldn't be included in the comparison, which gets it working properly.
