### PR TITLE
cp bugfix for deleted entries

### DIFF
--- a/NaveePlugin.php
+++ b/NaveePlugin.php
@@ -5,7 +5,7 @@ class NaveePlugin extends BasePlugin {
 
   public function getName()
   {
-    return 'Navee';
+    return Craft::t('Navee');
   }
 
   public function getVersion()

--- a/controllers/Navee_NodeController.php
+++ b/controllers/Navee_NodeController.php
@@ -128,7 +128,7 @@ class Navee_NodeController extends BaseController {
       $variables['entryElements'][]    = craft()->entries->getEntryById($variables['node']->entryId);
       $variables['assetElements'][]    = craft()->assets->getFileById($variables['node']->assetId);
       $variables['categoryElements'][] = craft()->categories->getCategoryById($variables['node']->categoryId);
-      
+
       // get a link to the element in the cp if it is an entry or category
       switch ($variables['node']->linkType)
       {
@@ -136,7 +136,9 @@ class Navee_NodeController extends BaseController {
           $criteria = craft()->elements->getCriteria(ElementType::Entry);
           $criteria->id = $variables['node']->entryId;
           $entry = $criteria->first();
-          $variables['node']->linkedElementCpEditUrl = $entry->getCpEditUrl();
+          if ($entry) {
+            $variables['node']->linkedElementCpEditUrl = $entry->getCpEditUrl();
+          }
           $variables['node']->linkedElementType = 'Entry';
           break;
         case 'categoryId':
@@ -147,7 +149,7 @@ class Navee_NodeController extends BaseController {
           $variables['node']->linkedElementType = 'Category';
           break;
       }
-      
+
     }
 
     if ($variables['navigation']->maxLevels != 1)

--- a/elementtypes/Navee_NodeElementType.php
+++ b/elementtypes/Navee_NodeElementType.php
@@ -127,6 +127,9 @@ class Navee_NodeElementType extends BaseElementType {
             $criteria->id = $element->entryId;
             $criteria->status = array(EntryModel::LIVE, EntryModel::PENDING, EntryModel::EXPIRED, EntryModel::ARCHIVED, EntryModel::DISABLED, EntryModel::ENABLED);
             $entry = $criteria->first();
+            if (!$entry) {
+              return '<a href="#" data-icon="alert"></a>';
+            }
             $cpEditUrl = $entry->getCpEditUrl();
             return '<a href="' . $cpEditUrl . '" data-icon="section"></a>';
             break;


### PR DESCRIPTION
Fixed an issue where Navee cp won't load if a linked entry was deleted.
Also added ability to translate 'Navee' in the sidemenu.
