### PR TITLE
Siblings of active and node ID fixes.

### DIFF
--- a/services/NaveeService.php
+++ b/services/NaveeService.php
@@ -656,10 +656,11 @@ class NaveeService extends BaseApplicationComponent {
             continue;
           }
         }
-        // start with the active node
+        // start with siblings of the active node
         elseif ($this->config->startWithSiblingsOfActive)
         {
-          if (!$this->nodeInBranchOfActiveNode($rootNode, $node) && !$node->active)
+          if ((!$this->nodeInBranchOfActiveNode($rootNode, $node) && !$node->active)
+              || ($node->level < $activeNode->level && !$node->descendantActive))
           {
             array_push($removedNodes, $node);
             unset($nodes[$k]);

--- a/services/NaveeService.php
+++ b/services/NaveeService.php
@@ -638,24 +638,6 @@ class NaveeService extends BaseApplicationComponent {
             continue;
           }
         }
-        // start with a given node id
-        elseif ((int) $this->config->startWithNodeId && isset($rootNode))
-        {
-          if ($node->lft <= $rootNode->lft || $node->rgt >= $rootNode->rgt)
-          {
-            unset($nodes[$k]);
-            continue;
-          }
-        }
-        // start with children of a given node id
-        elseif ((int) $this->config->startWithChildrenOfNodeId && isset($rootNode))
-        {
-          if ($node->lft < $rootNode->lft || $node->rgt > $rootNode->rgt)
-          {
-            unset($nodes[$k]);
-            continue;
-          }
-        }
         // start with siblings of the active node
         elseif ($this->config->startWithSiblingsOfActive)
         {
@@ -706,6 +688,24 @@ class NaveeService extends BaseApplicationComponent {
             continue;
           }
 
+        }
+      }
+      // start with a given node id
+      elseif ((int) $this->config->startWithNodeId && isset($rootNode))
+      {
+        if ($node->lft <= $rootNode->lft || $node->rgt >= $rootNode->rgt)
+        {
+          unset($nodes[$k]);
+          continue;
+        }
+      }
+      // start with children of a given node id
+      elseif ((int) $this->config->startWithChildrenOfNodeId && isset($rootNode))
+      {
+        if ($node->lft < $rootNode->lft || $node->rgt > $rootNode->rgt)
+        {
+          unset($nodes[$k]);
+          continue;
         }
       }
     }

--- a/services/NaveeService.php
+++ b/services/NaveeService.php
@@ -690,8 +690,9 @@ class NaveeService extends BaseApplicationComponent {
 
         }
       }
+      
       // start with a given node id
-      elseif ((int) $this->config->startWithNodeId && isset($rootNode))
+      if ((int) $this->config->startWithNodeId && isset($rootNode))
       {
         if ($node->lft <= $rootNode->lft || $node->rgt >= $rootNode->rgt)
         {


### PR DESCRIPTION
First of all, thanks for the great plugin!

In dealing with a few more complex site navigations I ran into a couple issues, it would be great if you could review my fixes and see if you would roll them back in to Navee.

**Issue 1**

`startWithSiblingsOfActive` was showing nodes at the same level but outside of the current branch. 

Full menu:

```
- Item 1
    - Item 1.1 
        - Item 1.1.1
        - Item 1.1.2
            - Item 1.1.2.1 (ACTIVE NODE)
            - Item 1.1.2.2
        - Item 1.1.3
            - Item 1.1.3.1
            - Item 1.1.3.2
    - Item 1.2
- Item 2
    - Item 2.1
    - Item 2.2
```

Unexpected problem:

```
- Item 1.1.2.1 (ACTIVE NODE)
- Item 1.1.2.2
- Item 1.1.3.1
- Item 1.1.3.2
```

Expected behavior and fix: only show direct siblings in the same branch.

```
- Item 1.1.2.1 (ACTIVE NODE)
- Item 1.1.2.2
```

**Issue 2**

`startWithNodeId` and `startWithChildrenOfNodeId` was not working unless there was an active node. 

Full menu (no active nodes):

```
- Item 1 (node id 98)
    - Item 1.1 
    - Item 1.2
- Item 2  (node id 99)
    - Item 2.1
    - Item 2.2
```

Unexpected problem (with parameter of `startWithChildrenOfNodeId: 98` ):

```
- Item 1.1
- Item 1.2
- Item 2.1
- Item 2.2
```

Expected behavior and fix: nav should always start with the node id specified, even if there is no currently active node at all.

```
- Item 1.1
- Item 1.2
```